### PR TITLE
Devops refactor

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,39 @@
+# ubuntu-22.04 by default
+ARG VARIANT="jammy"
+FROM mcr.microsoft.com/vscode/devcontainers/cpp:0-${VARIANT}
+
+ENV DEBIAN_FRONTEND=noninteractive
+# Feel like this shouldn't be needed but it drops me in / during build
+WORKDIR /workspace
+
+RUN apt-get update \
+    #
+    # Install dev tools and package dependencies 
+    && apt-get install -y clang-tidy clang-format doxygen graphviz gfortran \
+    libfftw3-dev liblapack-dev libopenblas-dev libudev-dev libusb-1.0.0-dev \
+    #
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+    
+# Install dependencies from vcpkg
+RUN vcpkg integrate install \
+    && vcpkg install catch2 \
+    && vcpkg install rapidjson \
+    && vcpkg install asio \
+    && vcpkg install cpp-httplib \
+    && vcpkg install armadillo \
+    && vcpkg install ryml
+    
+COPY lib/sdrplay-3.0.7/SDRplay_RSP_API-Linux-3.07.1.run /workspace/
+
+# Install shitty sdrplay API
+RUN chmod +x /workspace/SDRplay_RSP_API-Linux-3.07.1.run \
+    && /workspace/SDRplay_RSP_API-Linux-3.07.1.run --tar -xf \
+    && cp x86_64/libsdrplay_api.so.3.07  /usr/local/lib/libsdrplay_api.so \ 
+    && ln -s /usr/local/lib/libsdrplay_api.so /usr/local/lib/libsdrplay_api.so.3.07 \ 
+    && cp inc/* /usr/local/include \ 
+    && chmod 644 /usr/local/lib/libsdrplay_api.so /usr/local/lib/libsdrplay_api.so.3.07 \
+    && ldconfig
+    

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/docker-existing-docker-compose
+{
+	"name": "blah2 dev",
+
+	// Update the 'dockerComposeFile' list if you have more compose files or use different names.
+	// The .devcontainer/docker-compose.yml file contains any overrides you need/want to make.
+	"dockerComposeFile": [
+		"docker-compose.yml"
+	],
+
+	// The 'service' property is the name of the service for the container that VS Code should
+	// use. Update this value and .devcontainer/docker-compose.yml to the real service name.
+	"service": "blah2-dev",
+
+	// The optional 'workspaceFolder' property is the path VS Code should open by default when
+	// connected. This is typically a file mount in .devcontainer/docker-compose.yml
+	"workspaceFolder": "/workspace",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Uncomment the next line if you want start specific services in your Docker Compose config.
+	// "runServices": [],
+
+	// Uncomment the next line if you want to keep your containers running after VS Code shuts down.
+	// "shutdownAction": "none",
+
+	// Uncomment the next line to run commands after the container is created.
+	// "postCreateCommand": "cat /etc/os-release",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+	"customizations": {
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"ms-vscode.cpptools-extension-pack",
+			],
+		}
+	},
+
+	// Uncomment to connect as an existing user other than the container default. More info: https://aka.ms/dev-containers-non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.2"
+services:
+  blah2-dev:
+    user: vscode
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - type: bind
+        source: ..
+        target: /workspace
+    working_dir: /workspace
+    command: sleep infinity

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-build/*
+build*/*
 bin/*
 !build/README.md
 !bin/README.md

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,16 @@
 cmake_minimum_required(VERSION 3.8)
-  if(COMMAND cmake_policy)
-    cmake_policy(SET CMP0003 NEW)
-  endif(COMMAND cmake_policy)
+if(COMMAND cmake_policy)
+  cmake_policy(SET CMP0003 NEW)
+endif(COMMAND cmake_policy)
   
 project(blah2)
 include(CMakePrintHelpers)
+include(CTest)
 
 SET(CMAKE_CXX_STANDARD 20)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_CXX_EXTENSIONS OFF)
-
-SET (PROJECT_ROOT "${PROJECT_SOURCE_DIR}")
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_ROOT}/bin")
-SET (PROJECT_TEST_DIR "${PROJECT_SOURCE_DIR}/test")
-SET (PROJECT_SOURCE_DIR "${PROJECT_SOURCE_DIR}/src")
-SET (PROJECT_BINARY_DIR "${PROJECT_ROOT}/bin")
-SET (PROJECT_BINARY_TEST_DIR "${PROJECT_ROOT}/bin/test")
-SET (PROJECT_BINARY_TEST_UNIT_DIR "${PROJECT_ROOT}/bin/test/unit")
-SET (PROJECT_LIB_DIR "${PROJECT_ROOT}/lib")
-MESSAGE ("Source path: ${PROJECT_SOURCE_DIR}")
-MESSAGE ("Binary path: ${PROJECT_BINARY_DIR}")
-MESSAGE ("Binary test path: ${PROJECT_BINARY_TEST_DIR}")
-MESSAGE ("Lib path: ${PROJECT_LIB_DIR}")
-MESSAGE ("CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
 
 find_package(Threads REQUIRED)
 find_package(asio CONFIG REQUIRED)
@@ -32,7 +20,16 @@ find_package(httplib REQUIRED)
 find_package(Armadillo REQUIRED)
 find_package(Catch2 CONFIG REQUIRED)
 
-# find_package(fftw3 REQUIRED)
+# TODO: When release CI is finished, don't use these dirs, install target should go to prod
+SET (PROJECT_ROOT "${PROJECT_SOURCE_DIR}")
+SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_ROOT}/bin")
+SET (PROJECT_BINARY_TEST_DIR "${PROJECT_ROOT}/bin/test")
+
+MESSAGE ("Binary path: ${PROJECT_BINARY_DIR}")
+MESSAGE ("Binary test path: ${PROJECT_BINARY_TEST_DIR}")
+
+# Include from top-level src dir
+include_directories(src)
 
 # TODO: Create FindSdrplay.cmake for this
 add_library(sdrplay /usr/local/include/sdrplay_api.h)
@@ -68,35 +65,27 @@ target_link_libraries(blah2 PRIVATE
   fftw3
   fftw3_threads
   sdrplay
-  )
-
-include_directories("${PROJECT_SOURCE_DIR}/capture/")
-include_directories("${PROJECT_SOURCE_DIR}/capture/rspduo/")
-include_directories("${PROJECT_SOURCE_DIR}/process/ambiguity/")
-include_directories("${PROJECT_SOURCE_DIR}/process/clutter/")
-include_directories("${PROJECT_SOURCE_DIR}/process/detection/")
-include_directories("${PROJECT_SOURCE_DIR}/process/tracker/")
-include_directories("${PROJECT_SOURCE_DIR}/process/spectrum/")
-include_directories("${PROJECT_SOURCE_DIR}/process/meta/")
-include_directories("${PROJECT_SOURCE_DIR}/data/")
-include_directories("${PROJECT_SOURCE_DIR}/data/meta/")
+)
 
 # unit tests
 add_executable(testAmbiguity
-  ${PROJECT_TEST_DIR}/unit/process/ambiguity/TestAmbiguity.cpp
-  ${PROJECT_SOURCE_DIR}/data/IqData.cpp
-  ${PROJECT_SOURCE_DIR}/data/Map.cpp
-  ${PROJECT_SOURCE_DIR}/process/ambiguity/Ambiguity.cpp
-  ${PROJECT_SOURCE_DIR}/process/meta/HammingNumber.cpp)
+  test/unit/process/ambiguity/TestAmbiguity.cpp
+  src/data/IqData.cpp
+  src/data/Map.cpp
+  src/process/ambiguity/Ambiguity.cpp
+  src/process/meta/HammingNumber.cpp)
 target_link_libraries(testAmbiguity PRIVATE Catch2::Catch2WithMain fftw3 fftw3_threads)
 set_target_properties(testAmbiguity PROPERTIES 
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
 
 add_executable(testTracker
-  ${PROJECT_TEST_DIR}/unit/process/tracker/TestTracker.cpp
-  ${PROJECT_SOURCE_DIR}/data/Detection.cpp
-  ${PROJECT_SOURCE_DIR}/data/Track.cpp
-  ${PROJECT_SOURCE_DIR}/process/tracker/Tracker.cpp)
+  test/unit/process/tracker/TestTracker.cpp
+  src/data/Detection.cpp
+  src/data/Track.cpp
+  src/process/tracker/Tracker.cpp)
 target_link_libraries(testTracker PRIVATE Catch2::Catch2WithMain)
 set_target_properties(testTracker PROPERTIES 
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
+
+add_test(NAME testAmbiguity COMMAND testAmbiguity)
+add_test(NAME testTracker COMMAND testTracker)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,11 +7,6 @@ project(blah2)
 include(CMakePrintHelpers)
 include(CTest)
 
-SET(CMAKE_CXX_STANDARD 20)
-SET(CMAKE_CXX_STANDARD_REQUIRED ON)
-SET(CMAKE_CXX_EXTENSIONS OFF)
-SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_ROOT}/bin")
-
 find_package(Threads REQUIRED)
 find_package(asio CONFIG REQUIRED)
 find_package(RapidJSON REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,14 @@
-project(blah2)
 cmake_minimum_required(VERSION 3.8)
+  if(COMMAND cmake_policy)
+    cmake_policy(SET CMP0003 NEW)
+  endif(COMMAND cmake_policy)
+  
+project(blah2)
+include(CMakePrintHelpers)
 
-SET(CMAKE_CXX_STANDARD 17)
+SET(CMAKE_CXX_STANDARD 20)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_CXX_EXTENSIONS OFF)
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 SET (PROJECT_ROOT "${PROJECT_SOURCE_DIR}")
 SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_ROOT}/bin")
@@ -18,59 +22,53 @@ MESSAGE ("Source path: ${PROJECT_SOURCE_DIR}")
 MESSAGE ("Binary path: ${PROJECT_BINARY_DIR}")
 MESSAGE ("Binary test path: ${PROJECT_BINARY_TEST_DIR}")
 MESSAGE ("Lib path: ${PROJECT_LIB_DIR}")
+MESSAGE ("CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}")
+
+find_package(Threads REQUIRED)
+find_package(asio CONFIG REQUIRED)
+find_package(RapidJSON REQUIRED)
+find_package(ryml CONFIG REQUIRED)
+find_package(httplib REQUIRED)
+find_package(Armadillo REQUIRED)
+find_package(Catch2 CONFIG REQUIRED)
+
+# find_package(fftw3 REQUIRED)
+
+# TODO: Create FindSdrplay.cmake for this
+add_library(sdrplay /usr/local/include/sdrplay_api.h)
+set_target_properties(sdrplay PROPERTIES LINKER_LANGUAGE C)
+target_link_libraries(sdrplay PUBLIC /usr/local/lib/libsdrplay_api.so.3.07)
 
 add_executable(blah2
-  ${PROJECT_SOURCE_DIR}/blah2.cpp
-  ${PROJECT_SOURCE_DIR}/capture/Capture.cpp
-  ${PROJECT_SOURCE_DIR}/capture/rspduo/RspDuo.cpp
-  ${PROJECT_SOURCE_DIR}/process/ambiguity/Ambiguity.cpp
-  ${PROJECT_SOURCE_DIR}/process/clutter/WienerHopf.cpp
-  ${PROJECT_SOURCE_DIR}/process/detection/CfarDetector1D.cpp
-  ${PROJECT_SOURCE_DIR}/process/detection/Centroid.cpp
-  ${PROJECT_SOURCE_DIR}/process/detection/Interpolate.cpp
-  ${PROJECT_SOURCE_DIR}/process/tracker/Tracker.cpp
-  ${PROJECT_SOURCE_DIR}/process/spectrum/SpectrumAnalyser.cpp
-  ${PROJECT_SOURCE_DIR}/process/meta/HammingNumber.cpp
-  ${PROJECT_SOURCE_DIR}/data/IqData.cpp
-  ${PROJECT_SOURCE_DIR}/data/Map.cpp
-  ${PROJECT_SOURCE_DIR}/data/Detection.cpp
-  ${PROJECT_SOURCE_DIR}/data/Track.cpp
-  ${PROJECT_SOURCE_DIR}/data/meta/Timing.cpp
+  src/blah2.cpp
+  src/capture/Capture.cpp
+  src/capture/rspduo/RspDuo.cpp
+  src/process/ambiguity/Ambiguity.cpp
+  src/process/clutter/WienerHopf.cpp
+  src/process/detection/CfarDetector1D.cpp
+  src/process/detection/Centroid.cpp
+  src/process/detection/Interpolate.cpp
+  src/process/tracker/Tracker.cpp
+  src/process/spectrum/SpectrumAnalyser.cpp
+  src/process/meta/HammingNumber.cpp
+  src/data/IqData.cpp
+  src/data/Map.cpp
+  src/data/Detection.cpp
+  src/data/Track.cpp
+  src/data/meta/Timing.cpp
 )
 
-add_library(ryml ${PROJECT_LIB_DIR}/rapidyaml-0.5.0/ryml-0.5.0.hpp)
-add_library(rapidjson ${PROJECT_LIB_DIR}/rapidjson-1.1.0/)
-add_library(sdrplay /usr/local/include/sdrplay_api.h)
-add_library(asio ${PROJECT_LIB_DIR}/asio-1.26.0/asio.hpp)
-add_library(httplib ${PROJECT_LIB_DIR}/cpp-httplib-0.12.2/httplib.h)
-add_library(catch2 ${PROJECT_LIB_DIR}/catch2/catch_amalgamated.cpp)
-target_include_directories(catch2 PUBLIC ${PROJECT_LIB_DIR}/catch2)
-
-include_directories("${PROJECT_LIB_DIR}/rapidjson-1.1.0/")
-set_target_properties(rapidjson PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(blah2 rapidjson)
-
-include_directories("${PROJECT_LIB_DIR}/asio-1.26.0/")
-set_target_properties(asio PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(blah2 asio)
-
-include_directories("${PROJECT_LIB_DIR}/cpp-httplib-0.12.2/")
-set_target_properties(httplib PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(blah2 httplib)
-
-include_directories("${PROJECT_LIB_DIR}/rapidyaml-0.5.0/")
-set_target_properties(ryml PROPERTIES LINKER_LANGUAGE CXX)
-target_link_libraries(blah2 ryml)
-
-set_target_properties(sdrplay PROPERTIES LINKER_LANGUAGE C)
-target_link_libraries(sdrplay /usr/local/lib/libsdrplay_api.so.3.07)
-target_link_libraries(blah2 sdrplay)
-
-target_link_libraries(blah2 fftw3)
-target_link_libraries(blah2 fftw3_threads)
-target_link_libraries(blah2 lapack)
-target_link_libraries(blah2 blas)
-target_link_libraries(blah2 armadillo)
+target_link_libraries(blah2 PRIVATE 
+  Threads::Threads
+  rapidjson
+  asio::asio
+  ryml::ryml
+  httplib::httplib
+  armadillo
+  fftw3
+  fftw3_threads
+  sdrplay
+  )
 
 include_directories("${PROJECT_SOURCE_DIR}/capture/")
 include_directories("${PROJECT_SOURCE_DIR}/capture/rspduo/")
@@ -90,7 +88,7 @@ add_executable(testAmbiguity
   ${PROJECT_SOURCE_DIR}/data/Map.cpp
   ${PROJECT_SOURCE_DIR}/process/ambiguity/Ambiguity.cpp
   ${PROJECT_SOURCE_DIR}/process/meta/HammingNumber.cpp)
-target_link_libraries(testAmbiguity catch2 fftw3 fftw3_threads)
+target_link_libraries(testAmbiguity PRIVATE Catch2::Catch2WithMain fftw3 fftw3_threads)
 set_target_properties(testAmbiguity PROPERTIES 
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")
 
@@ -99,6 +97,6 @@ add_executable(testTracker
   ${PROJECT_SOURCE_DIR}/data/Detection.cpp
   ${PROJECT_SOURCE_DIR}/data/Track.cpp
   ${PROJECT_SOURCE_DIR}/process/tracker/Tracker.cpp)
-target_link_libraries(testTracker catch2)
+target_link_libraries(testTracker PRIVATE Catch2::Catch2WithMain)
 set_target_properties(testTracker PROPERTIES 
   RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_TEST_UNIT_DIR}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,145 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 21,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "cmake-pedantic",
+            "hidden": true,
+            "warnings": {
+                "dev": true,
+                "deprecated": true,
+                "unusedCli": true,
+                "systemVars": false
+            },
+            "errors": {
+                "dev": true,
+                "deprecated": true
+            }
+        },
+        {
+            "name": "cppcheck",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_CPPCHECK": "cppcheck;--inline-suppr"
+            }
+        },
+        {
+            "name": "clang-tidy",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_CLANG_TIDY": "clang-tidy",
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON"
+            }
+        },
+        {
+            "name": "ci-std",
+            "description": "This preset makes sure the project actually builds with at least the specified standard",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_CXX_EXTENSIONS": "OFF",
+                "CMAKE_CXX_STANDARD": "20",
+                "CMAKE_CXX_STANDARD_REQUIRED": "ON"
+            }
+        },
+        {
+            "name": "ci-vcpkg",
+            "hidden": true,
+            "description": "Bootstrap the toolchain with vcpkg installed paths",
+            "toolchainFile": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+        },
+        {
+            "name": "ci-build",
+            "binaryDir": "${sourceDir}/build/${presetName}",
+            "inherits": ["cmake-pedantic"],
+            "hidden": true
+        },
+        {
+            "name": "ci-unix",
+            "generator": "Unix Makefiles",
+            "hidden": true,
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Linux"
+            },
+            "inherits": [
+                "ci-std",
+                "ci-build",
+                "ci-vcpkg"
+            ]
+        },
+        {
+            "name": "ci-release",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "name": "ci-debug",
+            "hidden": true,
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "dev-unix-release",
+            "installDir": "$env{HOME}/.local",
+            "inherits": [
+                "ci-unix",
+                "ci-release"
+            ]
+        },
+        {
+            "name": "dev-unix-debug",
+            "inherits": [
+                "ci-unix",
+                "ci-debug"
+            ]
+        },
+        {
+            "name": "dev-unix-release-sa",
+            "inherits": [
+                "ci-unix",
+                "ci-release",
+                "clang-tidy"
+            ]
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "dev-unix-debug",
+            "configurePreset": "dev-unix-debug",
+            "configuration": "Debug",
+            "jobs": 4
+        },
+        {
+            "name": "dev-unix-release",
+            "configurePreset": "dev-unix-release",
+            "configuration": "Release",
+            "jobs": 4
+        },
+        {
+            "name": "dev-unix-release-sa",
+            "configurePreset": "dev-unix-release-sa",
+            "configuration": "Release",
+            "jobs": 4
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "test-all-unix-release",
+            "configurePreset": "dev-unix-release",
+            "output": {
+                "outputOnFailure": true
+            },
+            "execution": {
+                "jobs": 1
+            }
+        }
+    ]
+}

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -2,23 +2,24 @@
 /// @brief A real-time radar.
 /// @author 30hours
 
+#include "capture/Capture.h"
+#include "data/IqData.h"
+#include "data/Map.h"
+#include "data/Detection.h"
+#include "data/meta/Timing.h"
+#include "data/Track.h"
+#include "process/ambiguity/Ambiguity.h"
+#include "process/clutter/WienerHopf.h"
+#include "process/detection/CfarDetector1D.h"
+#include "process/detection/Centroid.h"
+#include "process/detection/Interpolate.h"
+#include "process/spectrum/SpectrumAnalyser.h"
+#include "process/tracker/Tracker.h"
+
 #include <ryml/ryml.hpp>
 #include <ryml/ryml_std.hpp> // optional header, provided for std:: interop
 #include <c4/format.hpp> // needed for the examples below
 #include <asio.hpp>
-#include <Capture.h>
-#include <Ambiguity.h>
-#include <WienerHopf.h>
-#include <CfarDetector1D.h>
-#include <Tracker.h>
-#include <IqData.h>
-#include <Map.h>
-#include <Detection.h>
-#include <Track.h>
-#include <Centroid.h>
-#include <Interpolate.h>
-#include <Timing.h>
-#include <SpectrumAnalyser.h>
 #include <sys/types.h>
 #include <getopt.h>
 #include <string>

--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -2,9 +2,9 @@
 /// @brief A real-time radar.
 /// @author 30hours
 
-#define RYML_SINGLE_HDR_DEFINE_NOW
-
-#include <ryml-0.5.0.hpp>
+#include <ryml/ryml.hpp>
+#include <ryml/ryml_std.hpp> // optional header, provided for std:: interop
+#include <c4/format.hpp> // needed for the examples below
 #include <asio.hpp>
 #include <Capture.h>
 #include <Ambiguity.h>

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -1,5 +1,5 @@
 #include "Capture.h"
-#include "RspDuo.h"
+#include "rspduo/RspDuo.h"
 #include <iostream>
 #include <thread>
 #include <httplib.h>

--- a/src/capture/Capture.h
+++ b/src/capture/Capture.h
@@ -7,7 +7,7 @@
 #define CAPTURE_H
 
 #include <string>
-#include <IqData.h>
+#include "data/IqData.h"
 
 class Capture
 {

--- a/src/capture/rspduo/RspDuo.cpp
+++ b/src/capture/rspduo/RspDuo.cpp
@@ -1,4 +1,5 @@
-#include <RspDuo.h>
+#include "RspDuo.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/capture/rspduo/RspDuo.h
+++ b/src/capture/rspduo/RspDuo.h
@@ -20,9 +20,10 @@
 #define RSPDUO_H
 
 #include "sdrplay_api.h"
+#include "data/IqData.h"
+
 #include <stdint.h>
 #include <string>
-#include <IqData.h>
 
 #define BUFFER_SIZE_NR 1024
 

--- a/src/data/Track.h
+++ b/src/data/Track.h
@@ -15,7 +15,8 @@
 #ifndef TRACK_H
 #define TRACK_H
 
-#include <Detection.h>
+#include "data/Detection.h"
+
 #include <stdint.h>
 #include <vector>
 #include <string>

--- a/src/process/ambiguity/Ambiguity.h
+++ b/src/process/ambiguity/Ambiguity.h
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <IqData.h>
-#include <Map.h>
-#include <HammingNumber.h>
+#include "data/IqData.h"
+#include "data/Map.h"
+#include "process/meta/HammingNumber.h"
 #include <stdint.h>
 #include <fftw3.h>
 #include <memory>

--- a/src/process/clutter/WienerHopf.h
+++ b/src/process/clutter/WienerHopf.h
@@ -9,7 +9,7 @@
 #ifndef WIENERHOPF_H
 #define WIENERHOPF_H
 
-#include <IqData.h>
+#include "data/IqData.h"
 #include <stdint.h>
 #include <fftw3.h>
 #include <armadillo>

--- a/src/process/detection/Centroid.h
+++ b/src/process/detection/Centroid.h
@@ -7,7 +7,7 @@
 #ifndef CENTROID_H
 #define CENTROID_H
 
-#include <Detection.h>
+#include "data/Detection.h"
 #include <stdint.h>
 
 class Centroid

--- a/src/process/detection/CfarDetector1D.cpp
+++ b/src/process/detection/CfarDetector1D.cpp
@@ -1,5 +1,6 @@
 #include "CfarDetector1D.h"
-#include "Map.h"
+#include "data/Map.h"
+
 #include <iostream>
 #include <vector>
 #include <cmath>

--- a/src/process/detection/CfarDetector1D.h
+++ b/src/process/detection/CfarDetector1D.h
@@ -8,8 +8,8 @@
 #ifndef CFARDETECTOR1D_H
 #define CFARDETECTOR1D_H
 
-#include <Map.h>
-#include <Detection.h>
+#include "data/Map.h"
+#include "data/Detection.h"
 #include <stdint.h>
 #include <complex>
 

--- a/src/process/detection/Interpolate.h
+++ b/src/process/detection/Interpolate.h
@@ -11,8 +11,8 @@
 #ifndef INTERPOLATE_H
 #define INTERPOLATE_H
 
-#include <Map.h>
-#include <Detection.h>
+#include "data/Map.h"
+#include "data/Detection.h"
 
 class Interpolate
 {

--- a/src/process/spectrum/SpectrumAnalyser.h
+++ b/src/process/spectrum/SpectrumAnalyser.h
@@ -9,7 +9,7 @@
 #ifndef SPECTRUMANALYSER_H
 #define SPECTRUMANALYSER_H
 
-#include <IqData.h>
+#include "data/IqData.h"
 #include <stdint.h>
 #include <fftw3.h>
 

--- a/src/process/tracker/Tracker.h
+++ b/src/process/tracker/Tracker.h
@@ -10,8 +10,8 @@
 #ifndef TRACKER_H
 #define TRACKER_H
 
-#include <Detection.h>
-#include <Track.h>
+#include "data/Detection.h"
+#include "data/Track.h"
 #include <stdint.h>
 
 class Tracker

--- a/test/unit/process/ambiguity/TestAmbiguity.cpp
+++ b/test/unit/process/ambiguity/TestAmbiguity.cpp
@@ -10,8 +10,10 @@
 #include <catch2/generators/catch_generators.hpp>
 
 #include "process/ambiguity/Ambiguity.h"
+
 #include <random>
 #include <iostream>
+#include <filesystem>
 
 /// @brief Use random_device as RNG.
 std::random_device g_rd;
@@ -147,6 +149,12 @@ TEST_CASE("Process_Simple", "[process]")
 /// @brief Test processing from a file.
 TEST_CASE("Process_File", "[process]")
 {
+    std::filesystem::path test_input_file("20231214-230611.rspduo");
+    // Bail if the test file doesn't exist
+    if (!std::filesystem::exists(test_input_file)) {
+      SKIP("Input test file does not exist.");
+    }
+    
     auto round_hamming = GENERATE(true, false);
 
     int32_t delayMin{-10};

--- a/test/unit/process/ambiguity/TestAmbiguity.cpp
+++ b/test/unit/process/ambiguity/TestAmbiguity.cpp
@@ -9,7 +9,7 @@
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 #include <catch2/generators/catch_generators.hpp>
 
-#include "Ambiguity.h"
+#include "process/ambiguity/Ambiguity.h"
 #include <random>
 #include <iostream>
 

--- a/test/unit/process/ambiguity/TestAmbiguity.cpp
+++ b/test/unit/process/ambiguity/TestAmbiguity.cpp
@@ -5,8 +5,9 @@
 /// @todo Add golden data IqData file for testing.
 /// @todo Declaration match to coding style?
 
-#define CATCH_CONFIG_MAIN
-#include "catch_amalgamated.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <catch2/generators/catch_generators.hpp>
 
 #include "Ambiguity.h"
 #include <random>

--- a/test/unit/process/tracker/TestTracker.cpp
+++ b/test/unit/process/tracker/TestTracker.cpp
@@ -4,9 +4,10 @@
 
 #include <catch2/catch_test_macros.hpp>
 
-#include "Detection.h"
-#include "Tracker.h"
-#include "Track.h"
+#include "data/Detection.h"
+#include "data/Track.h"
+#include "process/tracker/Tracker.h"
+
 #include <string>
 #include <vector>
 #include <random>

--- a/test/unit/process/tracker/TestTracker.cpp
+++ b/test/unit/process/tracker/TestTracker.cpp
@@ -2,8 +2,7 @@
 /// @brief Unit test for Tracker.cpp
 /// @author 30hours
 
-#define CATCH_CONFIG_MAIN
-#include "catch_amalgamated.hpp"
+#include <catch2/catch_test_macros.hpp>
 
 #include "Detection.h"
 #include "Tracker.h"


### PR DESCRIPTION
- The purpose of this branch is to ease development of the C++ components so that development and basic testing does not need to occur in production.
- Added a [devcontainer](https://code.visualstudio.com/docs/devcontainers/containers) for the C++ development environment. 
- CMake is now more idiomatic and uses presets for configuration.
- Not really sure what your development workflow is with respect to the node server and integrating with the hardware so I've left that out, but given more information, I can improve that flow too.

## Usage
- Follow the vscode article for devcontainer integration with vscode. 
- If you primarily use terminal and text editor, maybe look at [devcontainer cli](https://code.visualstudio.com/docs/devcontainers/devcontainer-cli).
- Once in the container, vscode makes configuring with the presets a doddle, or you can use: 
```
cmake -S. --preset dev-unix-release
cmake --build --preset dev-unix-release
```
from the terminal