### PR TITLE
Hackrf bug fixes v2

### DIFF
--- a/src/blah2.cpp
+++ b/src/blah2.cpp
@@ -307,7 +307,7 @@ int main(int argc, char **argv)
         }
       }
     });
-
+  t2.join();
   t1.join();
 
   return 0;

--- a/src/capture/Capture.cpp
+++ b/src/capture/Capture.cpp
@@ -61,7 +61,7 @@ void Capture::process(IqData *buffer1, IqData *buffer2, c4::yml::NodeRef config,
   {
     device->replay(buffer1, buffer2, file, loop);
   }
-
+  t1.join();
 }
 
 std::unique_ptr<Source> Capture::factory_source(const std::string& type, c4::yml::NodeRef config)

--- a/src/capture/Source.cpp
+++ b/src/capture/Source.cpp
@@ -67,6 +67,9 @@ void Source::kill()
   if (type == "RspDuo")
   {
     stop();
+  } else if (type == "HackRF")
+  {
+    stop();
   }
   exit(0);
 }

--- a/src/capture/hackrf/HackRf.cpp
+++ b/src/capture/hackrf/HackRf.cpp
@@ -76,6 +76,9 @@ void HackRf::start()
   check_status(status, "Failed to set VGA gain.");
   status = hackrf_set_hw_sync_mode(dev[1], 1);
   check_status(status, "Failed to enable hardware synchronising.");
+  status = hackrf_set_clkout_enable(dev[1], 1); 
+  check_status(status, "Failed to set CLKOUT on survillance device");
+
 
   // reference config
   status = hackrf_open_by_serial(serial[0].c_str(), &dev[0]);
@@ -104,14 +107,10 @@ void HackRf::stop()
 void HackRf::process(IqData *buffer1, IqData *buffer2)
 {
     int status;
-
-    while (true)
-    {
-      status = hackrf_start_rx(dev[1], rx_callback, buffer2);
-      check_status(status, "Failed to start RX streaming.");
-      status = hackrf_start_rx(dev[0], rx_callback, buffer1);
-      check_status(status, "Failed to start RX streaming.");
-    }
+    status = hackrf_start_rx(dev[1], rx_callback, buffer2);
+    check_status(status, "Failed to start RX streaming.");
+    status = hackrf_start_rx(dev[0], rx_callback, buffer1);
+    check_status(status, "Failed to start RX streaming.");
 }
 
 int HackRf::rx_callback(hackrf_transfer* transfer)


### PR DESCRIPTION
This PR will fix the previous crashes caused by threads not having correct termination points and causing extra code to run.

I have also added CLKOUT support to avoid the user inputting this every time they plug their devices.

Also, enabled the code flow path to HackRF::stop()